### PR TITLE
Abama.cai的作业

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+template<typename T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -16,19 +17,56 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+
+    std::vector<std::common_type_t<T1,T2>> c;
+
+    //add a b with common length
+    for(auto index = 0; index != std::min(a.size(),b.size()); ++index)
+    {
+        c.push_back(a[index]+b[index]);
+    }
+
+    return c;
 }
 
-template <class T1, class T2>
-std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
+template <class T1, class T2, class T>
+std::variant<T1, T2> operator+(std::variant<T1, T2>const &a,  T const & b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+
+    //判断结果容器的元素类型是否为T1的元素类型，或者是T2的元素类型
+    static_assert(std::is_same_v<std::common_type_t<typename T1::value_type, typename T::value_type>, typename T1::value_type>||
+            std::is_same_v<std::common_type_t<typename T2::value_type, typename T::value_type>, typename T2::value_type>);
+
+    return std::visit([&](auto &&arg1){
+        std::variant<T1,T2> v;
+        v=arg1+b;
+        return v;
+    }, a);
 }
 
 template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
+std::variant<T1, T2> operator+(std::variant<T1, T2>const &a, std::variant<T1, T2> const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([&](auto &&arg1, auto && arg2){
+        std::variant<T1,T2> v;
+        v=arg1+arg2;
+        return v;
+    }, a, b);
+}
+
+
+template <class T, class ...ARGN>
+std::ostream &operator<<(std::ostream &os, std::variant<T, ARGN...> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+
+    std::visit([&](auto && arg){
+       os << arg;
+    }, a);
+
+    return os;
 }
 
 int main() {


### PR DESCRIPTION
1 请修复这个函数的定义： 缺少了模板参数T的声明
2 请修复这个函数的定义： 找到T1 和T2的共同类型， 将这个共同类型，变成结果类型的vector 即可
3 请实现自动匹配容器中具体类型的加法： 看了有d+c 的使用，故重载了variant和vector加法的模板函数
4 请实现自动匹配容器中具体类型的打印： 在一个参数后面又加上了 可变参数， 避免了std::variant<> 模板参数为空的情况。