### PR TITLE
[feat] hw03 done

### DIFF
--- a/cpp_type_name.h
+++ b/cpp_type_name.h
@@ -27,3 +27,6 @@ std::string cpp_type_name() {
         s += " &&";
     return s;
 }
+
+
+#define SHOW(T) std::cout << cpp_type_name<T>() << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,12 @@
+#include <cstddef>
 #include <iostream>
 #include <vector>
 #include <variant>
 
+#include "cpp_type_name.h"
+
 // 请修复这个函数的定义：10 分
+template <class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -16,19 +20,48 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+decltype(auto) operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0 = decltype(T1{} + T2{});
+    std::vector<T0> res;
+    for(size_t i=0; i<a.size()&&i<b.size(); i++){
+        res.push_back(a[i]+b[i]);
+    }
+    return res;
 }
 
 template <class T1, class T2>
-std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
+decltype(auto) operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([&](auto const&x, auto const& y){
+        return x + y;
+    }, a, b);
+}
+
+template <class T1, class T2, class T3>
+decltype(auto) operator+(std::vector<T3> const &a, std::variant<T1, T2> const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([&](auto const&y){
+        return a + y;
+    }, b);
+}
+
+template <class T1, class T2, class T3>
+decltype(auto) operator+(std::variant<T1, T2> const &a, std::vector<T3> const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([&](auto const&x){
+        return x + b;
+    }, a);
 }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&](auto const& x){
+        os << x;
+    }, a);
+    return os;
 }
 
 int main() {
@@ -46,6 +79,7 @@ int main() {
 
     std::variant<std::vector<int>, std::vector<double>> d = c;
     std::variant<std::vector<int>, std::vector<double>> e = a;
+    
     d = d + c + e;
 
     // 应该输出 {9.28, 17.436, 7.236}

--- a/main.cpp
+++ b/main.cpp
@@ -20,43 +20,42 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-decltype(auto) operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
     using T0 = decltype(T1{} + T2{});
     std::vector<T0> res;
-    for(size_t i=0; i<a.size()&&i<b.size(); i++){
+    for(size_t i=0; i<std::min(a.size(),b.size()); i++){
         res.push_back(a[i]+b[i]);
     }
     return res;
 }
 
 template <class T1, class T2>
-decltype(auto) operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
+std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
-    return std::visit([&](auto const&x, auto const& y){
+    // 注意lambda要有返回值。
+    return std::visit([&](auto const&x, auto const& y)->std::variant<T1, T2> {
         return x + y;
     }, a, b);
 }
 
 template <class T1, class T2, class T3>
-decltype(auto) operator+(std::vector<T3> const &a, std::variant<T1, T2> const &b) {
+auto operator+(const T3&a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
-    return std::visit([&](auto const&y){
-        return a + y;
-    }, b);
+    std::variant<T1, T2> v_a = a; // 亮点。
+    return v_a + b;
 }
 
 template <class T1, class T2, class T3>
-decltype(auto) operator+(std::variant<T1, T2> const &a, std::vector<T3> const &b) {
+auto operator+(std::variant<T1, T2> const &a, const T3&b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
-    return std::visit([&](auto const&x){
-        return x + b;
-    }, a);
+    std::variant<T1, T2> v_b = b;
+    return a + v_b;
 }
 
-template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
+template <class T1, class ...ARGS>
+std::ostream &operator<<(std::ostream &os, std::variant<T1, ARGS...> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
     std::visit([&](auto const& x){
         os << x;


### PR DESCRIPTION
- 这次作业的难点在于计算`d = d + c + e`时， `decltype(auto) operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b)` 没办法对 `std::vector<double>` + `std::variant<int, double>`进行处理，因为前者已经被特化为两个variant相加。所以对`std::vector<double>`和`std::variant<int, double>`顺序进行排列组合，增加了两个重载函数。
- 为了自动推导返回类型，我将返回类型变为了`decltype(auto)`，但是这里还是有疑问，为了防止滥用自动推导，应该什么时候用`decltype(auto)`，什么时候不用呢？
- `std::visit`配合`lambda`非常好用！