### PR TITLE
homework03

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,8 +2,6 @@
 #include <vector>
 #include <variant>
 
-#include <tuple>
-
 // 请修复这个函数的定义：10 分
 template <class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,10 @@
 #include <vector>
 #include <variant>
 
+#include <tuple>
+
 // 请修复这个函数的定义：10 分
+template <class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -16,19 +19,54 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0 = decltype(T1{} + T2{});
+    std::vector<T0> ret;
+    size_t n = std::min(a.size(), b.size());
+    for (size_t i = 0; i < n; i ++) {
+        ret.push_back(a[i] + b[i]);
+    }
+    return ret;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    std::variant<T1, T2> ret;
+    std::visit([&] (auto const &t1, auto const &t2) {
+        ret = t1 + t2;
+    }, a, b);
+    return ret;
 }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&] (auto const &t) {
+        os << t;
+    }, a);
+    return os;
+}
+
+template <class T1, class T2>
+auto operator+(std::variant<T1, T2> const &a, T1 const &b) {
+    return a + std::variant<T1, T2>{b};
+}
+
+template <class T1, class T2>
+auto operator+(std::variant<T1, T2> const &a, T2 const &b) {
+    return a + std::variant<T1, T2>{b};
+}
+
+// 基于变长模板参数的<<运算符重载
+template <class T1, class...Types>
+std::ostream &operator<<(std::ostream &os, std::variant<T1, Types...> const &a) {
+    std::visit([&] (auto const &t) {
+        os << t;
+    }, a);
+    return os;
 }
 
 int main() {
@@ -50,6 +88,9 @@ int main() {
 
     // 应该输出 {9.28, 17.436, 7.236}
     std::cout << d << std::endl;
+
+    // expect: "Hello World!"
+    std::cout << std::variant<int, double, std::string>("Hello World!") << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
1. 修复std::vector<T> 的<<运算符重载：增加模板参数
2. 修复std::vector<T1>的+运算符重载：用auto自动推断返回值类型
3. 实现std::vector<T1>的+运算符重载：使用`decltype(T1{} + T2{})`推断返回值类型
4. 实现std::variant<T1, T2>的+运算符重载：使用visit
5. std::variant与std::vector的+运算符重载：将vector转换成variant
6. std::variant基于变长模板参数的<<运算符重载
