### PR TITLE
hw03 Gelee

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+template<class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -16,19 +17,68 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0 = decltype(T1{} + T2{});
+    const int n = std::min(a.size(),b.size());
+    std::vector<T0> res(n,0);
+    for(int i =0; i < n ; i++){
+        res[i] = a[i]+b[i];
+    }
+    return res;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
-}
+    return std::visit([&] (auto const &t1, auto const &t2)
+        ->std::variant<T1 ,T2>{
+        return  t1 + t2;
+    }, a, b);
+};
+
+
+
+template <class T1, class T2>
+auto operator+(std::variant<T1, T2> const &a, T2 const &b) {
+    std::variant<T1, T2> b1 = b;
+    return a + b1;
+};
+
+template <class T1, class T2, class T3>
+auto operator+(T3 const &a, std::variant<T1, T2> const &b) {
+    std::variant<T1, T2> a1 = a;
+    return  a1 + b;
+};
+
+//template <class T1, class T2>
+//auto operator+(std::variant<T1, T2> const &a, T2 const &b) {
+//    if(a.index() == 0){
+//        return std::get<T1>(a) + b;
+//    }else{
+//        return std::get<T2>(a) + b;
+//    }
+//};
+//
+//template <class T1, class T2, class T3>
+//auto operator+(T3 const &a, std::variant<T1, T2> const &b) {
+//    if(b.index() == 0){
+//        return a + std::get<T1>(b);
+//    }else{
+//        return a + std::get<T2>(b);
+//    }
+//};
+
+
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&](auto const & it){
+        os << it << std::endl;
+    },a);
+    return os;
 }
 
 int main() {


### PR DESCRIPTION
- 修复第一个函数：简单的加上template<class T>即可；

- 修复第二个函数：由下面的实际运算结果可知，结果的vector与二者中最短的相同，逐项相加即可。

- 自动匹配容器中具体类型的方法：
    此“+” 为 std::variant<T1, T2> + std::variant<T1, T2>; 使用课上讲的std::visit，有多个variant作为参数，visit会自动地罗列出所 
    有的排列组合。

- 自动匹配容器中具体类型的打印: 同理的使用std::visit即可。

- 关于 `d + c + e`:

编译器给的报错是：
> error C2676: 二进制“+”:“std::variant<std::vector<int,std::allocator<int>>,std::vector<double,std::allocator<double>>>”
> 不定义该运算符或到预定义运算符可接收的类型的转换

由此有了两种思路：
1.	对于`d + c`，重载运算符`+`，可以将c变为d的类型后，调用上面已写好的`std::variant<T1, T2> + std::variant<T1, T2>`的重载运算符`+`即可，这样子其实d + c + e 已经可以运算。但是若有表达式 `d = c + e` ， 则是不可以的。为了防止未知的情况，所以对于`c` 在运算符的左边的情况也需要重载。

2.	第二种思路则是利用`std::hold_alternative`或者`v.index `来获取`std::variant<T1, T2>`类型，然后对于 `d + c,  c + e`重载运算符将`+`时，使用`std::get<index>()`将`d ，e` 变为确定的类型， 然后调用关于`std::vector<T1> + std::vector<T2> `的重载运算符“+”即可。
