### PR TITLE
hw03

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,12 +2,23 @@
 #include <vector>
 #include <variant>
 #include <algorithm>
+#include <iterator>
+#include<ranges>
 
 // 请修复这个函数的定义：10 分
 template <class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
-    std::copy(std::begin(x), std::end(x),std::ostream_iterator(os, ", "));
+    // auto joined = a | std::view::transform([](int x) {return std::to_string(x);})
+    //                 | std::view::join(',');
+    // std::cout << std::to_string(joined);
+    // std::copy(std::begin(a), std::end(a),std::ostream_iterator<T>(os, ", "));
+    for(int i=0;i<a.size();i++)
+    {
+        os<<a[i];
+        if(i!=a.size()-1)
+        os<<", ";
+    }
     os << "}";
     return os;
 }
@@ -19,39 +30,33 @@ auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 例如 {1, 2} + {3, 4} = {4, 6}
     using T0=decltype(T1{}+T2{});
     std::vector<T0> c;
-    std::transform (a.begin(), a.end(), b.begin(), std::back_inserter(c), std::plus<int>());
+    auto sz = std::min(a.size(),b.size());
+    std::transform (begin(a), next(begin(a),sz), begin(b), std::back_inserter(c), [](auto x,auto y){return x+y;});
     return c;
 }
 
-template <class T1, class T2>
-std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T1 const &b)
+template <
+    class T1, class T2, class T3, 
+    std::enable_if_t<std::is_same_v<T1,T3>||std::is_same_v<T2,T3>,bool> = true
+>
+std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T3 const &b)
 {
-    return std::static_cast<std::variant<T1, T2>>(b)+a;
+    return static_cast<std::variant<T1, T2>>(b)+a;
 }
 
-template <class T1, class T2>
-std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T2 const &b)
+template <
+    class T1, class T2, class T3, 
+    std::enable_if_t<std::is_same_v<T1,T3>||std::is_same_v<T2,T3>,bool> = true
+>
+std::variant<T1, T2> operator+(T3 const &a, std::variant<T1, T2> const &b)
 {
-    return std::static_cast<std::variant<T1, T2>>(b)+a;
-}
-
-
-template <class T1, class T2>
-std::variant<T1, T2> operator+(T1 const &a, std::variant<T1, T2> const &b)
-{
-    return std::static_cast<std::variant<T1, T2>>(a)+b;
-}
-
-template <class T1, class T2>
-std::variant<T1, T2> operator+(T2 const &a, std::variant<T1, T2> const &b)
-{
-    return std::static_cast<std::variant<T1, T2>>(a)+b;
+    return static_cast<std::variant<T1, T2>>(a)+b;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
-    return std::visit([](auto const& x,auto const& y){return x+y;},a,b);
+    return std::visit([](auto const& x,auto const& y){return std::variant<T1,T2>{x+y};},a,b);
 }
 
 // template <class T1, class... T2>
@@ -63,12 +68,10 @@ std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
-    return std::visit(
-        [](auto const& x){
-            return os<<x;
-        },
-        a        
-    );
+    std::visit([&] (auto const &x) {
+        os << x;
+    }, a);
+    return os;
 }
 
 int main() {

--- a/main.cpp
+++ b/main.cpp
@@ -24,16 +24,41 @@ auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
 }
 
 template <class T1, class T2>
+std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T1 const &b)
+{
+    return std::static_cast<std::variant<T1, T2>>(b)+a;
+}
+
+template <class T1, class T2>
+std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T2 const &b)
+{
+    return std::static_cast<std::variant<T1, T2>>(b)+a;
+}
+
+
+template <class T1, class T2>
+std::variant<T1, T2> operator+(T1 const &a, std::variant<T1, T2> const &b)
+{
+    return std::static_cast<std::variant<T1, T2>>(a)+b;
+}
+
+template <class T1, class T2>
+std::variant<T1, T2> operator+(T2 const &a, std::variant<T1, T2> const &b)
+{
+    return std::static_cast<std::variant<T1, T2>>(a)+b;
+}
+
+template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
     return std::visit([](auto const& x,auto const& y){return x+y;},a,b);
 }
 
-template <class T1, class... T2>
-std::variant<T1, T2...> operator+(std::variant<T1, T2...> const &a, std::variant<T1, T2...> const &b) {
-    // 请实现自动匹配容器中具体类型的加法！10 分
-    return std::visit([](auto const& x,auto const& y){return x+(y + ...);},a,b);
-}
+// template <class T1, class... T2>
+// std::variant<T1, T2...> operator+(std::variant<T1, T2...> const &a, std::variant<T1, T2...> const &b) {
+//     // 请实现自动匹配容器中具体类型的加法！10 分
+//     return std::visit([](auto const& x,auto const& y){return x+(y + ...);},a,b);
+// }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {

--- a/main.cpp
+++ b/main.cpp
@@ -1,34 +1,49 @@
 #include <iostream>
 #include <vector>
 #include <variant>
+#include <algorithm>
 
 // 请修复这个函数的定义：10 分
+template <class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
-    for (size_t i = 0; i < a.size(); i++) {
-        os << a[i];
-        if (i != a.size() - 1)
-            os << ", ";
-    }
+    std::copy(std::begin(x), std::end(x),std::ostream_iterator(os, ", "));
     os << "}";
     return os;
 }
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0=decltype(T1{}+T2{});
+    std::vector<T0> c;
+    std::transform (a.begin(), a.end(), b.begin(), std::back_inserter(c), std::plus<int>());
+    return c;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([](auto const& x,auto const& y){return x+y;},a,b);
+}
+
+template <class T1, class... T2>
+std::variant<T1, T2...> operator+(std::variant<T1, T2...> const &a, std::variant<T1, T2...> const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([](auto const& x,auto const& y){return x+(y + ...);},a,b);
 }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    return std::visit(
+        [](auto const& x){
+            return os<<x;
+        },
+        a        
+    );
 }
 
 int main() {


### PR DESCRIPTION
主要难点在于d+c+e，需要分类讨论重载不同的情况，为了减少重载个数用了sfinae技术，使用enable_if_t，为了防止与之后的偏特化冲突把默认返回的void改成bool然后赋值为true。重载<<运算符不知道为什么无法像重载+一样直接return，必须单独return os，会报错无法复制os，但按理说都应该是引用才对。编译使用的版本是g++ 11.2，重载输出尝试使用c++20的ranges库，但是改了cmakelist的cXX为20还是会报错，不知道为什么还不支持。