### PR TITLE
temp&func

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,8 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
-std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
+template<class T>
+auto &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
         os << a[i];
@@ -16,19 +17,38 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0 = decltype(T1{} + T2{});
+    std::vector<T0> res;
+    for (size_t i = 0; i < std::min(a.size(), b.size()); i++)
+        res.push_back(a[i]+b[i]);
+    return res;
 }
 
 template <class T1, class T2>
-std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
+auto operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([] (auto const &a, auto const &b) -> std::variant<T1, T2> {
+        return a + b;
+    }, a, b);
+}
+
+// 重载+与参数顺序有关, 为了使得main函数中的d+c+e成功运行, 重载一个新的+
+template <class T1, class T2>
+auto operator+(std::variant<T1, T2> const &b, T2 const &a) {
+    std::variant<T1, T2> res = a;
+    return res + b;
 }
 
 template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
+auto &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&] (auto const &a) {
+        os << a;
+    }, a);
+    return os;
 }
 
 int main() {


### PR DESCRIPTION
1. 修复`vector`的`<<`重载函数

补充模板类`template<class T>`

2. 修复两个`vector`相加`+`重载函数+列表的逐元素加法

使用`using+decltype`获取相加后的类型，随后创建新类型的`vector`再for循环相加

3. 实现自动匹配容器`variant`中具体类型的加法

使用`visit`+`lambda`表达式得到`+`左右两个变量的类型，由于`vector`的加法在2中实现，故直接返回`a+b`

4. 实现自动匹配容器`variant`中具体类型的打印

也需要通过`visit`+`lambda`表达式得到`variant`中的具体类型，然后给`os`，随后返回`os`

5. `main()`中有`variant<vector<int>, vector<double>>`和`variant<double>`的加法，由于原程序中未实现，因此实现了`variant<T1, T2> const &b, T2 const &a`的加法，而且需要考虑参数顺序，否则还需要写一个重载函数（暂时未想到如何不考虑顺序）；且若是`variant<vector<int>, vector<double>>`和`variant<int>`的加法，则仍需做相应的加法重载，`main()`中没调用，就不再实现。

