### PR TITLE
hw03

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+template<class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -16,19 +17,40 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 
 // 请修复这个函数的定义：10 分
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+auto operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using T0 = decltype(T1{} + T2{});
+    std::vector<T0> ret;
+    for (size_t i = 0; i < std::min(a.size(), b.size()); i++) {
+        ret.push_back(a[i] + b[i]);
+    }
+    return ret;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([&](auto const& a, auto const& b) {
+        return std::variant<T1, T2>{a + b};
+    }, a, b);
 }
 
-template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
+template <class T1, class... Ts>
+std::ostream &operator<<(std::ostream &os, std::variant<T1, Ts...> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&](auto const& x) {
+        os << x; 
+    }, a);
+
+    return os;
+}
+
+template<class T0 , class T1 , class T2>
+auto operator+(std::variant<T0, T1> const& v, T2 const& x) {
+    return std::visit([&](auto const& a) {
+        return std::variant<T0, T1>{a + x};
+    }, v);
 }
 
 int main() {


### PR DESCRIPTION
1，缺少了模板声明
2，T0不需要声明，首先需要知道T1+T2的类型，用了decltype来得到对应类型的别名，逐个元素相加后返回
3，使用visit访问对应类型的variant值，相加后申明为对应类型的variant并返回
4，由于缺少variant类型与普通类型相加的操作符重载，所以额外增加了一个函数
5，使用了可变长操作符支持多参数，并使用visit访问对应类型变量并输出