### PR TITLE
hw03

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,12 @@
 #include <iostream>
+#include <ostream>
+#include <type_traits>
 #include <vector>
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+// A: 没有加模板声明
+template<typename T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -15,20 +19,38 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 }
 
 // 请修复这个函数的定义：10 分
+// 使用type_traits中的common_type
+// 为了让返回值长度短点，能否修改下一行为
+// template <class T1, class T2, class T3 = typename std::common_type<T1, T2>::type >
 template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+std::vector<typename std::common_type<T1, T2>::type> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    using elemtype = typename std::common_type<T1, T2>::type;
+    auto len = std::min(a.size(), b.size());
+    std::vector<elemtype> vec(len);
+    for (size_t i = 0; i != len; i++) {
+        vec[i] = a[i] + b[i];
+    }
+    return vec;
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit([](const auto &x, const auto &y) -> std::variant<T1, T2> {
+        return x + y;
+    }, a, b);
 }
 
-template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
+// 踩坑：如果只有一个变长模板参数，则会默认实例化出来一个变长参数为空的实例出来
+// 所以需要是 1 + * 的方式定义模板参数，不能只有一个 *
+template <typename Arg, typename ... More>
+std::ostream &operator<<(std::ostream &os, std::variant<Arg, More...> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    return std::visit([&](const auto &x) -> std::ostream& {
+        return os << x;
+    }, a);
 }
 
 int main() {
@@ -46,7 +68,10 @@ int main() {
 
     std::variant<std::vector<int>, std::vector<double>> d = c;
     std::variant<std::vector<int>, std::vector<double>> e = a;
-    d = d + c + e;
+
+    // 这里vector不能隐式转换为variant, 可能是因为T1, T2模板参数推断不出来？
+    // 不知道如何解决，只能强制转换了。
+    d = d + static_cast<std::variant<std::vector<int>, std::vector<double>>>(c) + e;
 
     // 应该输出 {9.28, 17.436, 7.236}
     std::cout << d << std::endl;


### PR DESCRIPTION
# 总结

- 使用`std::common_type<>` 可以获得“共同类型”，原理是三元运算符的返回值类型为共同类型
- 在定义变长模板参数时，如果只有一个变长模板参数，则会默认实例化出来一个变长参数为空的实例出来，此时会报错因为`std::variant`必须至少提供一个模板参数
  - 所以必须`template <typename Arg, typename ... More>`
- 发现`std::variant` 与 `std::vector`相加时无法匹配到定义的模板加法运算符函数
  - 推测是此时模板参数无法推断，因为定义的模板函数第二个参数为`std::variant<T1, T2>`，此时加号右边是`vector<double>`。
  - 如果手动定义指定模板类型，定义一个非模板函数的话，可以顺利通过编译，`vector`会被隐式转换为`variant`
  - 此处不知道如何解决，所以只能把`vector`静态类型转换为`variant`

