### PR TITLE
finished

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+template <typename T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -15,20 +16,42 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 }
 
 // 请修复这个函数的定义：10 分
-template <class T1, class T2>
+template <class T1, class T2, typename T0 = decltype(std::declval<T1>() + std::declval<T2>())>
 std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    auto size{ std::min(a.size(), b.size()) };
+    std::vector<T0> c(size);
+    for (std::size_t i{ }; i < size; ++i)
+    {
+        c[i] = a[i] + b[i];
+    }
+    return c; 
 }
 
 template <class T1, class T2>
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+    return std::visit(
+        [](auto &&lhs, auto &&rhs) -> std::variant<T1, T2>
+        {
+            return lhs + rhs;
+        }, 
+        a, b
+    );
 }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit(
+        [&os](auto &&rhs)
+        {
+            os << rhs;
+        }, 
+        a
+    );
+    return os;
 }
 
 int main() {
@@ -46,7 +69,7 @@ int main() {
 
     std::variant<std::vector<int>, std::vector<double>> d = c;
     std::variant<std::vector<int>, std::vector<double>> e = a;
-    d = d + c + e;
+    d = d + static_cast<decltype(d + e)>(c) + e;
 
     // 应该输出 {9.28, 17.436, 7.236}
     std::cout << d << std::endl;


### PR DESCRIPTION
1. 缺了模板参数定义；
2. 因为模板参数T0无法编译器自行推导，通过模板默认参数和decltype辅助推导；
3. 4. [std::visit](https://zh.cppreference.com/w/cpp/utility/variant/visit);
5. c 是vector<double>，不是variant<vector<int>, vector<double> >，没有匹配的“+”运算符重载函数，所以
    5.1 把它类型转化为variant<vector<int>, vector<double> >；
    5.2 或者重载“+”运算符函数。