### PR TITLE
Update main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -48,13 +48,6 @@ std::variant<T1, T2> operator+(T1  const &a, std::variant<T1, T2> const &b) {
     return b + std::variant<T1, T2>{a};
 }
 
-template <class T1, class T2>
-std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
-    // 请实现自动匹配容器中具体类型的打印！10 分
-    std::visit([&](const auto& i){std::cout << i << std::endl;}, a);
-    return os;
-}
-
 template <class T1,class... Targs>
 std::ostream &operator<<(std::ostream &os, std::variant<T1,Targs...> const &args){
     std::visit([&](const auto& i){std::cout << i << std::endl;}, args);
@@ -81,7 +74,7 @@ int main() {
     // 应该输出 {9.28, 17.436, 7.236}
     std::cout << d << std::endl;
 
-    std::variant<int, double, std::vector<int>> temp{666};
+    std::variant<int> temp{666};
     std::cout << temp << std::endl;
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 // 请修复这个函数的定义：10 分
+template<class T>
 std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
     os << "{";
     for (size_t i = 0; i < a.size(); i++) {
@@ -15,20 +16,49 @@ std::ostream &operator<<(std::ostream &os, std::vector<T> const &a) {
 }
 
 // 请修复这个函数的定义：10 分
-template <class T1, class T2>
-std::vector<T0> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
+template <class T1, class T2>   // 第一个加法，  vector相加
+std::vector<std::common_type_t<T1,T2>> operator+(std::vector<T1> const &a, std::vector<T2> const &b) {
     // 请实现列表的逐元素加法！10 分
     // 例如 {1, 2} + {3, 4} = {4, 6}
+    std::vector<std::common_type_t<T1,T2>> sum;
+    size_t N = std::min(a.size(), b.size());
+    for (size_t i=0;i<N;i++){
+        sum.push_back(a[i] + b[i]);
+    }
+    return sum;
 }
 
-template <class T1, class T2>
+template <class T1, class T2>   // 第二个加法，   variant+variant
 std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, std::variant<T1, T2> const &b) {
     // 请实现自动匹配容器中具体类型的加法！10 分
+
+    return std::visit([&](const auto& i, const auto& j)->std::variant<T1, T2> {return i + j;}, a, b);
+}
+
+template <class T1, class T2>   // 第二个加法，   variant+vector
+std::variant<T1, T2> operator+(std::variant<T1, T2> const &a, T2 const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+
+    return a + std::variant<T1, T2>{b};
+}
+
+template <class T1, class T2>   // 第二个加法，   vector+variant
+std::variant<T1, T2> operator+(T1  const &a, std::variant<T1, T2> const &b) {
+    // 请实现自动匹配容器中具体类型的加法！10 分
+    return b + std::variant<T1, T2>{a};
 }
 
 template <class T1, class T2>
 std::ostream &operator<<(std::ostream &os, std::variant<T1, T2> const &a) {
     // 请实现自动匹配容器中具体类型的打印！10 分
+    std::visit([&](const auto& i){std::cout << i << std::endl;}, a);
+    return os;
+}
+
+template <class T1,class... Targs>
+std::ostream &operator<<(std::ostream &os, std::variant<T1,Targs...> const &args){
+    std::visit([&](const auto& i){std::cout << i << std::endl;}, args);
+    return os;
 }
 
 int main() {
@@ -50,6 +80,9 @@ int main() {
 
     // 应该输出 {9.28, 17.436, 7.236}
     std::cout << d << std::endl;
+
+    std::variant<int, double, std::vector<int>> temp{666};
+    std::cout << temp << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
- vector逐元素相加：使用std::common_type_t<>，获得相加结果的返回值，然后就是两个vector按位置相加。
- 两个variant相加：使用visit+lambda访问variant元素，调用上面定义"两个vector逐元素相加"的 +运算符；这里结果直接return，没有构造额外的variant对象。
- variant+vector和vector+variant：这里实现的较冗余、重复，定义了较相似的两个函数；其实，就是通过vector构造variant对象，再调用“两个variant相加”的+运算符。
- variant类型的，可变长度模板参数的<<重载：通过visit+lambda表达式访问，通过...修饰模板类型及参数；这里使用template <class T1,class... Targs>，确保至少有一个参数传进来，保证有参数传给<<进行重载。

hw3，磕磕绊绊，不太熟练地完成了。哈哈~~~